### PR TITLE
Fix bug where exception with code 0 cannot be rendered

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -94,7 +94,7 @@ class Handler extends ExceptionHandler
                     $error,
                 ],
             ],
-            $e->getCode(),
+            $e->getCode() ? $e->getCode() : 500,
             [
                 'Content-Type' => 'application/vnd.api+json',
             ]


### PR DESCRIPTION
Ran into this issue during unit testing causing the actual exception not being rendered and a new exception is thrown that rendering an exception with code 0 is not allowed.