### PR TITLE
🐞 Getting the shop ID from webhook payload for callback requests

### DIFF
--- a/app/Statuses/Http/Requests/ShipmentStatusCallbackRequest.php
+++ b/app/Statuses/Http/Requests/ShipmentStatusCallbackRequest.php
@@ -8,6 +8,7 @@ use App\Authentication\Domain\Token;
 use App\Exceptions\RequestInputException;
 use App\Exceptions\RequestUnauthorizedException;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Arr;
 use MyParcelCom\Integration\ShopId;
 use Ramsey\Uuid\Exception\InvalidUuidStringException;
 use Ramsey\Uuid\Uuid;
@@ -45,10 +46,10 @@ class ShipmentStatusCallbackRequest extends FormRequest
 
     public function shopId(): ShopId
     {
-        $shopId = $this->query('shop_id');
+        $shopId = Arr::get($this->getShipmentData(), 'relationships.shop.data.id');
 
         if (!$shopId) {
-            throw new RequestInputException('Bad request', 'No shop_id provided in the request query');
+            throw new RequestInputException('Bad request', 'No shop_id provided in the request body');
         }
 
         try {

--- a/tests/Feature/ShipmentStatusCallbackTest.php
+++ b/tests/Feature/ShipmentStatusCallbackTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature;
 use App\Authentication\Domain\ExpiresAt;
 use App\Authentication\Domain\Token;
 use Carbon\Carbon;
+use Illuminate\Support\Arr;
 use Tests\TestCase;
 
 class ShipmentStatusCallbackTest extends TestCase
@@ -19,9 +20,10 @@ class ShipmentStatusCallbackTest extends TestCase
 
         $requestStub = file_get_contents(base_path('tests/Stubs/status-request.json'));
         $data = json_decode($requestStub, true);
+        Arr::set($data, 'included.1.relationships.shop.data.id', $token->shop_id->toString());
 
         $response = $this->post(
-            '/callback/shipment-statuses?shop_id=' . $token->shop_id,
+            '/callback/shipment-statuses',
             $data
         );
 


### PR DESCRIPTION
# Changes
The shop ID should be retrieved from the POST body instead of query parameters for statuses callbacks.