### PR TITLE
Tests should reflect pagination

### DIFF
--- a/app/Shipments/Http/Controllers/ShipmentController.php
+++ b/app/Shipments/Http/Controllers/ShipmentController.php
@@ -124,11 +124,11 @@ class ShipmentController
     }
 
     /**
-     * @param int $pageNumber
-     * @param int $pageSize
+     * @param int|null $pageNumber
+     * @param int|null $pageSize
      * @return int|null
      */
-    private function pageOffset(int $pageNumber, int $pageSize): ?int
+    private function pageOffset(?int $pageNumber, ?int $pageSize): ?int
     {
         if (!$pageNumber || !$pageSize) {
             return null;

--- a/app/Shipments/Http/Requests/ShipmentRequest.php
+++ b/app/Shipments/Http/Requests/ShipmentRequest.php
@@ -75,7 +75,7 @@ class ShipmentRequest extends FormRequest
      */
     public function pageNumber(): ?int
     {
-        return $this->query('page_number') ? (int) $this->query('page_number') : null;
+        return $this->query('page.number') ? (int) $this->query('page.number') : null;
     }
 
     /**
@@ -83,6 +83,6 @@ class ShipmentRequest extends FormRequest
      */
     public function pageSize(): ?int
     {
-        return $this->query('page_size') ? (int) $this->query('page_size') : null;
+        return $this->query('page.size') ? (int) $this->query('page.size') : null;
     }
 }

--- a/tests/Feature/GetShipmentsTest.php
+++ b/tests/Feature/GetShipmentsTest.php
@@ -43,8 +43,8 @@ class GetShipmentsTest extends TestCase
             . $token->shop_id
             . '&filter[start_date]=2020-01-01'
             . '&filter[end_date]=2022-01-01'
-            . '&page_number=1'
-            . '&page_size=10'
+            . '&page[number]=1'
+            . '&page[size]=10'
         );
 
         $response->assertStatus(200);
@@ -75,8 +75,8 @@ class GetShipmentsTest extends TestCase
             . $token->shop_id
             . '&filter[start_date]=2020-01-01'
             . '&filter[end_date]=2022-01-01'
-            . '&page_number=1'
-            . '&page_size=10'
+            . '&page[number]=1'
+            . '&page[size]=10'
         );
 
         $response->assertStatus(200);

--- a/tests/Feature/GetShipmentsTest.php
+++ b/tests/Feature/GetShipmentsTest.php
@@ -43,6 +43,8 @@ class GetShipmentsTest extends TestCase
             . $token->shop_id
             . '&filter[start_date]=2020-01-01'
             . '&filter[end_date]=2022-01-01'
+            . '&page_number=1'
+            . '&page_size=10'
         );
 
         $response->assertStatus(200);


### PR DESCRIPTION
I noticed this test when I was developing on one of the integrations so I added the params into the skeleton since they are used in every integration that has pagination.